### PR TITLE
Adding support for open graph tags

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
-require "bundler/gem_tasks"
-
+require 'bundler/gem_tasks'

--- a/lib/seo.rb
+++ b/lib/seo.rb
@@ -1,4 +1,4 @@
-require "seo/version"
+require 'seo/version'
 require 'seo/tag_helper'
 
 module Seo
@@ -6,4 +6,3 @@ module Seo
 end
 
 ActionView::Base.send :include, Seo
-

--- a/lib/seo/tag_helper.rb
+++ b/lib/seo/tag_helper.rb
@@ -12,20 +12,33 @@ module Seo
       @tags[property] = content
     end
 
-    def meta_tags(og:true)
-      @tags ||= {}
-      output = "";
+    def build_meta_tags(tags)
+      output = ''
 
-      @tags.each do |property, content|
-        if property == 'title'
+      tags.each do |property, content|
+
+        if property.start_with? 'title'
           output << content_tag(:title, content)
         else
           output << tag(:meta, property: property, content: content)
         end
       end
 
+      output
+    end 
+
+    def meta_tags(og:true)
+      @tags ||= {}
+
+      output = build_meta_tags(@tags)
+
+      if og
+         @og_tags = Hash[@tags.map { |tag, value| ["og:#{tag}", value] }]
+         output << build_meta_tags(@og_tags)
+      end
+
       output.html_safe
-    end
+   end
   end
 end
 

--- a/lib/seo/tag_helper.rb
+++ b/lib/seo/tag_helper.rb
@@ -16,7 +16,6 @@ module Seo
       output = ''
 
       tags.each do |property, content|
-
         if property.start_with? 'title'
           output << content_tag(:title, content)
         else
@@ -25,7 +24,7 @@ module Seo
       end
 
       output
-    end 
+    end
 
     def meta_tags(og:true)
       @tags ||= {}
@@ -33,12 +32,11 @@ module Seo
       output = build_meta_tags(@tags)
 
       if og
-         @og_tags = Hash[@tags.map { |tag, value| ["og:#{tag}", value] }]
-         output << build_meta_tags(@og_tags)
+        @og_tags = Hash[@tags.map { |tag, value| ["og:#{tag}", value] }]
+        output << build_meta_tags(@og_tags)
       end
 
       output.html_safe
-   end
+    end
   end
 end
-

--- a/lib/seo/version.rb
+++ b/lib/seo/version.rb
@@ -1,3 +1,3 @@
 module Seo
-  VERSION = "0.0.1"
+  VERSION = '0.0.1'
 end

--- a/seo-meta-tags.gemspec
+++ b/seo-meta-tags.gemspec
@@ -4,23 +4,23 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'seo/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "seo-meta-tags"
+  spec.name          = 'seo-meta-tags'
   spec.version       = Seo::VERSION
-  spec.authors       = ["Mark Gandolfo"]
-  spec.email         = ["mark@gandolfo.com.au"]
+  spec.authors       = ['Mark Gandolfo']
+  spec.email         = ['mark@gandolfo.com.au']
   spec.summary       = %q{Meta Tags builder}
   spec.description   = %q{A meta tag builder}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'actionpack', '>= 4.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 end

--- a/spec/seo_tags_spec.rb
+++ b/spec/seo_tags_spec.rb
@@ -12,7 +12,7 @@ describe Seo do
   context 'tags' do
     it 'should allow tags to be added' do
       subject.set_meta('description', 'a description')
-      output = subject.meta_tags og:false
+      output = subject.meta_tags og: false
 
       expect(output).to eq("<meta property=\"description\" content=\"a description\" />")
     end
@@ -27,7 +27,7 @@ describe Seo do
     it 'should overwrite tags with the same property' do
       subject.set_meta('description', 'a description')
       subject.set_meta('description', 'a new description')
-      output = subject.meta_tags og:false
+      output = subject.meta_tags og: false
 
       expect(output).to eq("<meta property=\"description\" content=\"a new description\" />")
     end
@@ -35,7 +35,7 @@ describe Seo do
     it 'should overwrite tags with the same property and add og tags automatically' do
       subject.set_meta('description', 'a description')
       subject.set_meta('description', 'a new description')
-      output = subject.meta_tags og:true
+      output = subject.meta_tags og: true
 
       expect(output).to eq("<meta property=\"description\" content=\"a new description\" /><meta property=\"og:description\" content=\"a new description\" />")
     end
@@ -44,7 +44,7 @@ describe Seo do
   context 'title' do
     it 'should allow titles to be added using a special helper' do
       subject.set_title('my title')
-      output = subject.meta_tags og:false
+      output = subject.meta_tags og: false
 
       expect(output).to eq('<title>my title</title>')
     end
@@ -52,9 +52,7 @@ describe Seo do
     it 'should allow titles to be added using a special helper and automatically generate og' do
       subject.set_title('my title')
       output = subject.meta_tags
- 
       expect(output).to eq('<title>my title</title><meta property="og:title" content="my title" />')
     end
   end
 end
-

--- a/spec/seo_tags_spec.rb
+++ b/spec/seo_tags_spec.rb
@@ -12,26 +12,48 @@ describe Seo do
   context 'tags' do
     it 'should allow tags to be added' do
       subject.set_meta('description', 'a description')
-      output = subject.meta_tags
+      output = subject.meta_tags og:false
 
       expect(output).to eq("<meta property=\"description\" content=\"a description\" />")
+    end
+
+    it 'should automatically add og tags' do
+      subject.set_meta('description', 'a description')
+      output = subject.meta_tags
+
+      expect(output).to eq("<meta property=\"description\" content=\"a description\" /><meta property=\"og:description\" content=\"a description\" />")
     end
 
     it 'should overwrite tags with the same property' do
       subject.set_meta('description', 'a description')
       subject.set_meta('description', 'a new description')
-      output = subject.meta_tags
+      output = subject.meta_tags og:false
 
       expect(output).to eq("<meta property=\"description\" content=\"a new description\" />")
+    end
+
+    it 'should overwrite tags with the same property and add og tags automatically' do
+      subject.set_meta('description', 'a description')
+      subject.set_meta('description', 'a new description')
+      output = subject.meta_tags og:true
+
+      expect(output).to eq("<meta property=\"description\" content=\"a new description\" /><meta property=\"og:description\" content=\"a new description\" />")
     end
   end
 
   context 'title' do
     it 'should allow titles to be added using a special helper' do
       subject.set_title('my title')
-      output = subject.meta_tags
+      output = subject.meta_tags og:false
 
       expect(output).to eq('<title>my title</title>')
+    end
+
+    it 'should allow titles to be added using a special helper and automatically generate og' do
+      subject.set_title('my title')
+      output = subject.meta_tags
+ 
+      expect(output).to eq('<title>my title</title><meta property="og:title" content="my title" />')
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
 require 'bundler/setup'
 require 'action_view'
 require 'seo'
-


### PR DESCRIPTION
A small attempt at adding support for open graph tags automatically.
Installed rubocop and fixed most warnings except long line lengths
